### PR TITLE
Fix Zillow optimizer and add scrollable container support

### DIFF
--- a/docs/MCP_INTEGRATION.md
+++ b/docs/MCP_INTEGRATION.md
@@ -104,7 +104,7 @@ Gets the accessibility tree (a11y DOM) of a browser tab. Returns a structured re
 | Parameter | Type   | Required | Description                    |
 |-----------|--------|----------|--------------------------------|
 | `tab_id`  | number | Yes      | The tab ID to get the tree from |
-| `usePlatformOptimizer` | boolean | No | Use platform-specific formatting if available (default: false) |
+| `usePlatformOptimizer` | boolean | No | Use platform-specific formatting if available (default: true) |
 
 **Returns (default):**
 ```json

--- a/packages/chrome-extension-unpacked/handlers/accessibility.js
+++ b/packages/chrome-extension-unpacked/handlers/accessibility.js
@@ -62,11 +62,11 @@ function buildRefContext(tab_id, nodes, refs) {
  *
  * @param {Object} params
  * @param {number} params.tab_id - Target tab ID
- * @param {boolean} [params.usePlatformOptimizer=false] - Use platform-specific formatting if available
+ * @param {boolean} [params.usePlatformOptimizer=true] - Use platform-specific formatting if available
  * @returns {Promise<Object>} Formatted tree and element count
  */
 export async function getAccessibilityTree(params) {
-  const { tab_id, usePlatformOptimizer = false } = params;
+  const { tab_id, usePlatformOptimizer = true } = params;
 
   if (!tab_id) {
     throw new Error('tab_id is required');

--- a/packages/server-for-chrome-extension/src/mcp-handler.js
+++ b/packages/server-for-chrome-extension/src/mcp-handler.js
@@ -84,7 +84,7 @@ function createMcpHandler(extensionBridge, apiKey) {
           },
           usePlatformOptimizer: {
             type: 'boolean',
-            description: 'Use platform-specific formatting if available (e.g., Threads feed parser). Default: false'
+            description: 'Use platform-specific formatting if available (e.g., Threads feed parser). Default: true'
           }
         },
         required: ['tab_id']
@@ -380,7 +380,7 @@ function createMcpHandler(extensionBridge, apiKey) {
         commandType = 'get_accessibility_tree';
         commandParams = {
           tab_id: args.tab_id,
-          usePlatformOptimizer: args.usePlatformOptimizer ?? false
+          usePlatformOptimizer: args.usePlatformOptimizer ?? true
         };
         break;
 


### PR DESCRIPTION
## Summary
- **Fix filter detection**: Search `nodeMap` for `role="generic"` in addition to `role="region"` so Zillow filters are found regardless of markup changes
- **Add `activeFilter` extraction**: When a filter dialog is open, extract all interactive elements (checkboxes, radios, textboxes, comboboxes, sliders, buttons) so the AI can fully interact with filter controls (Price, Beds & Baths, Home Type, More)
- **Add scrollable container support**: Detect when click/scroll targets are inside overflow containers (e.g., the More filter dialog) and scroll the container with easeInOutCubic animation instead of the page
- **Refactor scroll utilities**: Extract shared `generateScrollAnimationCode` to eliminate duplication between window and container scrolling
- **Default `usePlatformOptimizer` to `true`** for accessibility tree requests

## Test plan
- [x] Open Zillow homepage, type a city, click autocomplete suggestion
- [x] Open each filter (For Sale, Price, Beds & Baths, Home Type, More) and verify `activeFilter` shows all controls
- [x] Set price range via textboxes in Price filter and verify results narrow
- [x] Select/deselect home types and verify results update
- [x] Scroll to Keywords field in More dialog (tests container scroll) and type a keyword
- [ ] Verify all filter changes reflected in URL parameters and result count

?? Generated with [Claude Code](https://claude.com/claude-code)