### PR TITLE
fix: parse all Zillow listing card types

### DIFF
--- a/packages/chrome-extension-unpacked/formatters/zillow_search.js
+++ b/packages/chrome-extension-unpacked/formatters/zillow_search.js
@@ -172,11 +172,16 @@ export function formatSearchPage(context) {
 function extractSearchListing(listitemNode, context) {
   const { nodeMap, getRef, getNodeName, getNodeRole, getNodeUrl, findChildrenByRole } = context;
 
-  // Find the main property link (contains /homedetails/)
+  // Find the main property link — accept any Zillow listing URL rather than
+  // allowlisting specific path patterns (homedetails, community, etc.)
   const links = findChildrenByRole(listitemNode.nodeId, 'link');
   const propertyLink = links.find(l => {
     const url = getNodeUrl(l);
-    return url && url.includes('/homedetails/');
+    if (!url) return false;
+    // Skip links that are clearly not property listings
+    if (url.includes('/profile/') || url.includes('/reviews/') || url.includes('/myzillow/')) return false;
+    // Must be a Zillow property path (relative or absolute)
+    return url.includes('zillow.com/') || url.startsWith('/');
   });
   if (!propertyLink) return null;
 
@@ -268,6 +273,9 @@ function extractSearchListing(listitemNode, context) {
       break;
     }
   }
+
+  // Skip non-listing items (e.g. pagination links) that matched broadly
+  if (!price) return null;
 
   return [url, price, beds, baths, sqft, status, address, agent, saveRef, listingRef];
 }


### PR DESCRIPTION
## Summary
- Zillow search formatter only matched `/homedetails/` URLs, missing builder/community cards with `/community/` URLs (7 of 13 listings invisible)
- Switched from allowlist to denylist approach — accepts any Zillow property link, skips non-listing URLs (`/profile/`, `/reviews/`, `/myzillow/`)
- Added price guard to filter out pagination links that match broadly

## Test plan
- [x] Verified on live Zillow search page (Katy TX new homes) — all 13 listings captured (6 homedetails + 7 community)
- [x] Pagination links correctly filtered out

🤖 Generated with [Claude Code](https://claude.com/claude-code)