### PR TITLE
fix(autostart): Electron owns Windows login auto-start

### DIFF
--- a/packages/electron/electron/main.js
+++ b/packages/electron/electron/main.js
@@ -3,6 +3,7 @@ const path = require('path');
 const fs = require('fs');
 
 const isDev = !app.isPackaged;
+const isHiddenLaunch = process.argv.includes('--hidden');
 
 let win = null;
 let tray = null;
@@ -121,6 +122,9 @@ function createWindow() {
     backgroundColor: '#0e0e10',
     icon: iconPath,
     title: 'WebPilot',
+    // Hidden boot (login auto-start with --hidden): start invisible so the
+    // app sits in the tray. Tray click still reveals via showWindow().
+    show: !isHiddenLaunch,
     webPreferences: {
       // No preload: the splash is pure CSS and the dashboard runs against
       // its own HTTP server; neither needs an IPC bridge.
@@ -140,6 +144,8 @@ function createWindow() {
     win.loadFile(path.join(__dirname, 'splash.html'));
   }
 
+  // Hidden boot launch (--hidden, e.g. login auto-start): preload the URL
+  // but never show the window. The tray click reveals it on demand.
   waitForServerHealthThenSwap();
 
   // Hide-to-tray on window close — only an explicit tray Exit (or
@@ -245,6 +251,54 @@ function quitFully() {
 }
 
 // ---------------------------------------------------------------------------
+// Auto-start (login item)
+// ---------------------------------------------------------------------------
+
+// Electron owns auto-start. On login we relaunch ourselves with --hidden so
+// the app boots straight to the tray and the spawned server runs as a hidden
+// child (no console window, no browser pop). The legacy entry registered by
+// the standalone server binary (HKCU Run\WebPilotServer) is migrated away on
+// first run so the old foreground server stops launching at boot.
+function ensureAutoStart() {
+  if (isDev) return; // never register dev builds
+  try {
+    if (process.platform === 'win32' || process.platform === 'darwin') {
+      const current = app.getLoginItemSettings();
+      if (!current.openAtLogin) {
+        app.setLoginItemSettings({
+          openAtLogin: true,
+          args: ['--hidden'],
+          path: process.execPath,
+        });
+      }
+    }
+  } catch (e) {
+    console.log('ensureAutoStart: failed to register login item: ' + (e && e.message));
+  }
+
+  // Best-effort migration: remove the legacy server Run key entry. The old
+  // standalone server registered itself here and would otherwise keep
+  // popping a console + browser tab at boot.
+  if (process.platform === 'win32') {
+    try {
+      const { execFile } = require('child_process');
+      execFile(
+        'reg',
+        [
+          'delete',
+          'HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run',
+          '/v',
+          'WebPilotServer',
+          '/f',
+        ],
+        { windowsHide: true },
+        () => { /* swallow errors — entry may not exist */ },
+      );
+    } catch { /* ignore */ }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // App lifecycle
 // ---------------------------------------------------------------------------
 
@@ -260,6 +314,7 @@ if (!gotLock) {
 
   app.whenReady().then(() => {
     ensureDataDir();
+    ensureAutoStart();
     startServer();
     createTray();
     createWindow();

--- a/packages/server-for-chrome-extension/cli.js
+++ b/packages/server-for-chrome-extension/cli.js
@@ -176,6 +176,14 @@ function isAlreadyRunning() {
 
 // Auto-register service if not already registered
 function autoRegister() {
+  // Skip when launched as a child of the Electron desktop app. Electron owns
+  // auto-start (via app.setLoginItemSettings) and spawns this binary hidden
+  // with WEBPILOT_NO_OPEN=1 and WEBPILOT_DATA_DIR set. Registering ourselves
+  // in the Run key would resurrect the legacy console-spawning entry on next
+  // boot.
+  if (process.env.WEBPILOT_NO_OPEN === '1' || process.env.WEBPILOT_DATA_DIR) {
+    return;
+  }
   try {
     const service = require('./src/service');
     const result = service.status();


### PR DESCRIPTION
## Summary
- Electron now registers itself for login auto-start via `app.setLoginItemSettings({ openAtLogin: true, args: ['--hidden'], path: process.execPath })`. On `--hidden` boot the BrowserWindow is created with `show: false` so the app sits in the tray; tray click reveals it via the existing `showWindow()` path.
- Migration: on every Electron launch (prod only) we best-effort `reg delete HKCU\Software\Microsoft\Windows\CurrentVersion\Run /v WebPilotServer /f` so the legacy console-spawning Run-key entry goes away.
- The standalone server's `autoRegister()` short-circuits when launched as Electron'''s child (detects `WEBPILOT_NO_OPEN=1` or `WEBPILOT_DATA_DIR`), so it can'''t silently re-register the old entry. `--install` / `--uninstall` on the standalone CLI still work for headless use.

### Why
On boot the HKCU `WebPilotServer` Run entry launched `server.exe --foreground` → console window appeared and Chrome opened to `localhost:3456/ui/` (because `WEBPILOT_NO_OPEN` wasn'''t set on that path). Electron itself never registered for auto-start. End state: no console, no browser pop, Electron hidden to tray with the dashboard preloaded.

## Test plan
- [ ] Install the v2.0.3 build produced by Release (patch).
- [ ] Verify HKCU Run now contains only an Electron entry (no `WebPilotServer`).
- [ ] Reboot. Confirm: no console window, no Chrome popup, WebPilot tray icon present.
- [ ] Click tray icon → BrowserWindow opens with the dashboard already loaded.
- [ ] Run `server.exe --install` (standalone path) → still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)