### PR TITLE
feat(server): auto-surface formatter error diagnostics inline (#57)

### DIFF
--- a/docs/MCP_INTEGRATION.md
+++ b/docs/MCP_INTEGRATION.md
@@ -304,7 +304,7 @@ Each formatter declares its workflows in `manifest.json` under `workflows[]` and
 | `intent` | string | No | Optional debug trace. |
 
 **Returns:**
-On success, an object of shape `{ ok: true, ...result }` where `result` is whatever the workflow's `run()` function returned. On failure, `{ ok: false, error: "<message>" }` with `isError: true` set on the MCP response.
+On success, an object of shape `{ ok: true, ...result }` where `result` is whatever the workflow's `run()` function returned. On failure, `{ ok: false, error: "<message>", diagnostics: {...} }` with `isError: true` set on the MCP response. The `diagnostics` object includes `phase`, `workflow`, `platform`, `tabId`, and error context.
 
 **Example (Discord — `send_message`):**
 ```
@@ -320,7 +320,8 @@ webpilot_run_workflow(
 Internally this workflow fetches the formatted accessibility tree, locates the composer textbox via `findInTree(tree, { name: 'Message textbox' })`, clicks it, types the supplied text, and presses Enter — one MCP round-trip instead of four.
 
 **Notes:**
-- Workflow runtime errors are recorded to per-formatter logs (`formatter-logs.js`) with `phase: 'workflow'` so the Web UI Formatters tab surfaces them under each formatter's recent-errors list.
+- Workflow runtime errors include inline `diagnostics` in the error response (phase, workflow, platform, tabId), so you can see what failed without calling `webpilot_dev_get_formatter_logs`.
+- Errors are also recorded to per-formatter logs so the Web UI Formatters tab can surface recent errors for pattern analysis.
 - Workflow parameters are type-checked against the manifest declaration (string/number/boolean/object/array). All parameters are treated as optional unless explicitly required by the workflow's `run()` implementation.
 - Workflows execute server-side using the same internal browser primitives as the MCP tool dispatch — so per-agent profile routing, visual cursor, auth, and refs all keep working transparently.
 
@@ -550,6 +551,7 @@ Refs (e1, e2, e3...) are stable identifiers for each element. These can be used 
 - `tab_id is required` - Missing tab_id parameter
 - `Another debugger is already attached to this tab` - DevTools or another extension is debugging the tab
 - `Failed to attach debugger: ...` - Tab may not exist or be a protected page (chrome://, etc.)
+- Formatter errors return `{ ok: false, error: "<message>", diagnostics: {...} }` (rather than throwing). The `diagnostics` object includes `phase`, `platform`, `tabId`, and error context.
 
 **Notes:**
 - Uses Chrome DevTools Protocol via the debugger API
@@ -1092,7 +1094,7 @@ The `webpilot_dev_*` namespace exists for formatter authors iterating against a 
 
 | Tool | What it does |
 |------|--------------|
-| `webpilot_dev_get_formatter_logs` | Returns the recent error ring buffer (most-recent-first) and a health summary (`successCount`, `errorCount`, `lastSuccessAt`, `lastErrorAt`, `health`, `lastError`) for one platform. Auth-exempt (read-only). Takes `platform` (required), plus optional `limit` / filters — see source for the full schema. |
+| `webpilot_dev_get_formatter_logs` | Get error history for a platform formatter. Workflow and accessibility-tree errors already include the most recent diagnostic inline, so this is typically only needed when investigating multiple failures or developing a new formatter. Auth-exempt (read-only). |
 | `webpilot_dev_reload_extension` | Triggers a `chrome.runtime.reload()` on the *calling agent's* paired Chrome profile. Requires auth. Multi-profile installs need one call per profile. Used when iterating on extension code; safe to skip in normal agent flows. |
 
 See `accessibility-tree-formatters/DEV_GUIDE.md` for the formatter dev loop these tools support.

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -187,6 +187,8 @@ Tools are exposed to AI agents. All tools except `request_pairing`, `check_pairi
 
 Navigational tools (`browser_create_tab`, `browser_close_tab`, `browser_click`, `browser_scroll`, `browser_type`, `webpilot_run_workflow`) also accept an optional `intent` string — a short human-readable description of *why* the call is being made. The value is purely additive: it surfaces in server-side debug logs as `[mcp:intent] <tool>: <text>` and is ignored by tool execution. Not validated, not required — but strongly encouraged for non-trivial flows to make debug traces readable.
 
+**Error responses for formatter-related tools** (`webpilot_run_workflow`, `browser_get_accessibility_tree`) include an inline `diagnostics` object — `{ phase, workflow, platform, tabId, topFrame, more }` — so agents can see what failed without calling `webpilot_dev_get_formatter_logs` for history.
+
 | Tool | Description | Key Parameters |
 |------|-------------|----------------|
 | `request_pairing` | Initiate **async** pairing — returns a `pairing_id` immediately; the human approves via the web UI. Short-circuits and returns the existing identity if the caller already presents a valid API key. | `agent_name` |
@@ -203,8 +205,8 @@ Navigational tools (`browser_create_tab`, `browser_close_tab`, `browser_click`, 
 | `browser_request_chain` | Execute multiple tool calls sequentially with result referencing | `steps`, `return_mode?` |
 | `webpilot_get_formatter_info` | Get info on available platform-specific formatters and instructions for creating custom platform optimizers | `platform?` |
 | `webpilot_reload_formatters` | DEVELOPER TOOL. Reload all formatters (auto-updated + custom) without restarting the server. Auth-gated (reloads code from disk → mutates server state). | (none) |
-| `webpilot_dev_get_formatter_logs` | DEVELOPER TOOL. Returns health summary + recent error ring-buffer entries for one platform formatter. Auth-exempt (strictly read-only inspection). | `platform`, `limit?` |
-| `webpilot_dev_reload_extension` | DEVELOPER TOOL. Triggers `chrome.runtime.reload()` in the extension service worker bound to the caller's profile, so edits under `packages/chrome-extension-unpacked/` take effect without manually reloading from `chrome://extensions/`. Per-profile scope only — other paired agents must call it from their own profile to reload everywhere. WS drops momentarily; the paired API key persists. | `api_key?` |
+| `webpilot_dev_get_formatter_logs` | Get error history for a platform formatter. Workflow and tool errors already include the most recent diagnostic inline, so this is typically only needed when investigating multiple failures, comparing across runs, or developing a new formatter. Returns up to 50 entries from the per-formatter ring buffer. | `platform`, `limit?` |
+| `webpilot_dev_reload_extension` | Triggers `chrome.runtime.reload()` in the extension service worker bound to the caller's profile, so edits under `packages/chrome-extension-unpacked/` take effect without manually reloading from `chrome://extensions/`. Per-profile scope only — other paired agents must call it from their own profile to reload everywhere. WS drops momentarily; the paired API key persists. | `api_key?` |
 | `webpilot_run_workflow` | Execute a platform-specific workflow (e.g. `discord/send_message`) that bundles multiple primitive actions into one named operation. Workflow names + parameters come from each formatter's manifest. | `platform`, `workflow`, `tab_id`, `params?` |
 
 ### `browser_request_chain`

--- a/packages/server-for-chrome-extension/package.json
+++ b/packages/server-for-chrome-extension/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "bin": "cli.js",
   "scripts": {
+    "test": "node test/formatter-diagnostics.test.js",
     "start": "node index.js",
     "dev": "cross-env WEBPILOT_DEV=1 node --watch index.js",
     "dev:network": "cross-env WEBPILOT_DEV=1 node --watch index.js --network",

--- a/packages/server-for-chrome-extension/src/formatter-logs.js
+++ b/packages/server-for-chrome-extension/src/formatter-logs.js
@@ -69,6 +69,16 @@ function truncateStack(stack) {
   return stack.slice(0, STACK_MAX) + '\n[truncated]';
 }
 
+function extractTopFrame(stack) {
+  if (!stack || typeof stack !== 'string') return null;
+  const match = stack.match(/at\s+([^(]+)\s+\(([^)]+):(\d+):\d+\)/);
+  if (!match) return null;
+  const fn = match[1].trim();
+  const file = require('path').basename(match[2]);
+  const line = match[3];
+  return `${file}:${line} (${fn})`;
+}
+
 function ensureFormatter(name) {
   let entry = state.get(name);
   if (!entry) {
@@ -259,7 +269,11 @@ function recordError(formatterName, info = {}) {
   try {
     emitter.emit('changed', { name: formatterName, status: statusForEntry(entry) });
   } catch (_e) { /* listener errors are not our problem */ }
+
+  return incident;
 }
+
+// New recordError call sites must also be wired into the inline-diagnostics augmentation path (see buildDiagnostics).
 
 /**
  * Per-incident dismiss. Updates the DB row and, if the row is in any
@@ -539,6 +553,18 @@ function cleanupDismissedIncidents(maxAgeDays = 90) {
   return { removed: res.changes, kept: remaining };
 }
 
+// Build a compact diagnostic payload from a recorded incident for inline MCP error responses.
+function buildDiagnostics(incident, platform) {
+  return {
+    phase: incident.phase,
+    workflow: incident.workflow ?? null,
+    platform,
+    tabId: incident.tabId ?? null,
+    topFrame: extractTopFrame(incident.stack),
+    more: `Call webpilot_dev_get_formatter_logs({platform: '${platform}'}) for full error history.`
+  };
+}
+
 /**
  * Test seam: clears the in-memory state + counters and resets the
  * hydration flag so the next call re-reads from the DB. Does NOT touch
@@ -561,6 +587,8 @@ module.exports = {
   listAll,
   flush,
   cleanupDismissedIncidents,
+  extractTopFrame,
+  buildDiagnostics,
   // EventEmitter used by server.js to bridge incident updates to the UI
   // WebSocket. Emits `'changed'` with `{ name, status }` after recordError,
   // recordSuccess, recordDismiss, and recordDismissAll. See server.js

--- a/packages/server-for-chrome-extension/src/formatter-manager.js
+++ b/packages/server-for-chrome-extension/src/formatter-manager.js
@@ -325,8 +325,13 @@ function formatTree(url, rawNodes) {
 
   // Match URL to platform
   if (url) {
+    let hostname;
     try {
-      const hostname = new URL(url).hostname;
+      hostname = new URL(url).hostname;
+    } catch (err) {
+      console.warn('[formatter-manager] URL parsing failed:', err.message);
+    }
+    if (hostname) {
       for (const [platformName, platformConfig] of Object.entries(manifest.platforms)) {
         if (hostname.includes(platformConfig.match)) {
           const baseDir = customPlatforms.has(platformName) ? customFormatterDir : formatterDir;
@@ -340,7 +345,7 @@ function formatTree(url, rawNodes) {
             return result;
           } catch (err) {
             console.warn(`[formatter-manager] Platform formatter ${platformName} failed:`, err.message);
-            formatterLogs.recordError(platformName, { error: err, phase: 'format' });
+            const incident = formatterLogs.recordError(platformName, { error: err, phase: 'format' });
 
             // Honor per-formatter `errorHandling.fallbackToRawTree` (defaults
             // to true if the per-formatter manifest is missing or did not
@@ -348,14 +353,14 @@ function formatTree(url, rawNodes) {
             const pm = perFormatterManifests[platformName];
             const fallback = !pm || !pm.errorHandling || pm.errorHandling.fallbackToRawTree !== false;
             if (!fallback) {
+              err.__formatterIncident = incident;
+              err.__platform = platformName;
               throw err;
             }
             // Fall through to default
           }
         }
       }
-    } catch (err) {
-      console.warn('[formatter-manager] URL parsing failed:', err.message);
     }
   }
 

--- a/packages/server-for-chrome-extension/src/mcp-handler.js
+++ b/packages/server-for-chrome-extension/src/mcp-handler.js
@@ -649,7 +649,7 @@ function createMcpHandler(extensionBridge, pairedKeys, formatterManager, isPairi
     },
     {
       name: 'webpilot_dev_get_formatter_logs',
-      description: 'DEVELOPER TOOL. Get health summary + recent error log entries for one platform formatter. Use this when iterating on a formatter or workflow to see why it failed — each entry includes the error message, truncated stack trace, phase (`format` for formatter errors during accessibility-tree rendering, `workflow` for errors raised inside `webpilot_run_workflow`), the workflow name + params + tabId for workflow errors, and an ISO timestamp. The `health` field summarizes overall activity ({ health: "healthy"|"unhealthy"|"unknown", lastError, successCount, errorCount, lastSuccessAt, lastErrorAt }). Note: only error entries are stored in the ring buffer; successful invocations bump counters and update `lastSuccessAt` but produce no log row. Pair with webpilot_reload_formatters to iterate quickly: edit → reload → run → call this if anything broke. Returns { platform, health, entries: [...], totalReturned, requestedLimit }.',
+      description: 'Get error history for a platform formatter. Workflow and tool errors already include the most recent diagnostic inline, so this is typically only needed when investigating multiple failures, comparing across runs, or developing a new formatter. Returns up to 50 entries from the per-formatter ring buffer.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -1143,6 +1143,9 @@ Naming convention: \`webpilot_dev_*\` = developer-iteration tools. \`webpilot_*\
     try {
       formatted = formatterManager.formatTree(formatterUrl, nodes);
     } catch (err) {
+      if (err.__formatterIncident) {
+        throw err;
+      }
       console.warn('[mcp-handler] Formatter error, falling back to default:', err.message);
       formatted = formatterManager.formatTree(null, nodes);
     }
@@ -1787,16 +1790,22 @@ Naming convention: \`webpilot_dev_*\` = developer-iteration tools. \`webpilot_*\
         });
         return { content: [{ type: 'text', text: JSON.stringify({ ok: true, ...(result && typeof result === 'object' ? result : { result }) }) }] };
       } catch (err) {
-        formatterLogs.recordError(platform, {
-          error: err,
-          phase: 'workflow',
-          workflow,
-          params: workflowParams,
-          tabId: workflowTabId
-        });
+        let incident;
+        if (err.__formatterIncident) {
+          incident = err.__formatterIncident;
+        } else {
+          incident = formatterLogs.recordError(platform, {
+            error: err,
+            phase: 'workflow',
+            workflow,
+            params: workflowParams,
+            tabId: workflowTabId
+          });
+        }
+        const diagnostics = formatterLogs.buildDiagnostics(incident, platform);
         console.warn(`[mcp:workflow] ${platform}/${workflow} failed: ${err.message}`);
         return {
-          content: [{ type: 'text', text: JSON.stringify({ ok: false, error: err.message }) }],
+          content: [{ type: 'text', text: JSON.stringify({ ok: false, error: err.message, diagnostics }) }],
           isError: true
         };
       }
@@ -1848,13 +1857,24 @@ Naming convention: \`webpilot_dev_*\` = developer-iteration tools. \`webpilot_*\
       }
 
       case 'browser_get_accessibility_tree': {
-        const responseData = await _browserGetAccessibilityTree(args, apiKey);
-        return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify(responseData, null, 2)
-          }]
-        };
+        try {
+          const responseData = await _browserGetAccessibilityTree(args, apiKey);
+          return {
+            content: [{
+              type: 'text',
+              text: JSON.stringify(responseData, null, 2)
+            }]
+          };
+        } catch (err) {
+          if (err.__formatterIncident) {
+            const diagnostics = formatterLogs.buildDiagnostics(err.__formatterIncident, err.__platform);
+            return {
+              content: [{ type: 'text', text: JSON.stringify({ ok: false, error: err.message, diagnostics }) }],
+              isError: true
+            };
+          }
+          throw err;
+        }
       }
 
       case 'browser_inject_script':

--- a/packages/server-for-chrome-extension/test/formatter-diagnostics.test.js
+++ b/packages/server-for-chrome-extension/test/formatter-diagnostics.test.js
@@ -1,0 +1,236 @@
+'use strict';
+
+/**
+ * Tests for issue #57: formatter error diagnostics.
+ * Covers extractTopFrame, buildDiagnostics, workflow/format error paths,
+ * and the no-double-record invariant.
+ */
+
+const assert = require('assert');
+
+// ---------------------------------------------------------------------------
+// Stub db/connection so formatter-logs can run without a real SQLite DB.
+// ---------------------------------------------------------------------------
+const Module = require('module');
+const origLoad = Module._load.bind(Module);
+let _stubIncidentId = 1;
+const _insertedRows = [];
+
+Module._load = function (request, parent, isMain) {
+  if (request === './db/connection' || (parent && parent.filename && parent.filename.includes('formatter-logs') && request.includes('connection'))) {
+    const fakeDb = {
+      prepare(sql) {
+        return {
+          run(...args) {
+            _insertedRows.push({ sql, args });
+            return { lastInsertRowid: _stubIncidentId++ };
+          },
+          get() { return null; },
+          all() { return []; }
+        };
+      }
+    };
+    return { getDb: () => fakeDb };
+  }
+  return origLoad(request, parent, isMain);
+};
+
+// Now load formatter-logs with the stub in place.
+const formatterLogs = require('../src/formatter-logs');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function makeIncident(overrides = {}) {
+  return {
+    id: 1,
+    formatter: 'test-platform',
+    timestamp: '2026-01-01T00:00:00.000Z',
+    phase: 'workflow',
+    workflow: 'doThing',
+    message: 'oops',
+    stack: '    at Timeout._onTimeout (extension-bridge.js:141:5)\n    at listOnTimeout (node:internal/timers:559:17)',
+    params: { url: 'https://example.com' },
+    tabId: 42,
+    dismissedAt: null,
+    dismissedBy: null,
+    ...overrides
+  };
+}
+
+// ---------------------------------------------------------------------------
+// extractTopFrame
+// ---------------------------------------------------------------------------
+{
+  const { extractTopFrame } = formatterLogs;
+
+  // Valid V8 stack with one frame
+  const stack = '    at Timeout._onTimeout (extension-bridge.js:141:5)\n    at listOnTimeout (node:internal/timers:559:17)';
+  const result = extractTopFrame(stack);
+  assert.strictEqual(result, 'extension-bridge.js:141 (Timeout._onTimeout)', `extractTopFrame valid: got ${result}`);
+
+  // Absolute path — only basename should appear
+  const stackAbs = '    at MyClass.method (/home/user/code/formatter-manager.js:88:12)';
+  const resultAbs = extractTopFrame(stackAbs);
+  assert.strictEqual(resultAbs, 'formatter-manager.js:88 (MyClass.method)', `extractTopFrame abs path: got ${resultAbs}`);
+
+  // Garbage input returns null
+  assert.strictEqual(extractTopFrame(null), null, 'extractTopFrame null → null');
+  assert.strictEqual(extractTopFrame(''), null, 'extractTopFrame empty → null');
+  assert.strictEqual(extractTopFrame('no frames here'), null, 'extractTopFrame garbage → null');
+  assert.strictEqual(extractTopFrame(42), null, 'extractTopFrame non-string → null');
+
+  console.log('extractTopFrame: PASS');
+}
+
+// ---------------------------------------------------------------------------
+// buildDiagnostics — exact key set, correct values
+// ---------------------------------------------------------------------------
+{
+  const { buildDiagnostics } = formatterLogs;
+
+  const incident = makeIncident({ phase: 'workflow', workflow: 'doThing', tabId: 42 });
+  const diag = buildDiagnostics(incident, 'myplatform');
+
+  // Exact key set — no extra keys
+  const keys = Object.keys(diag).sort();
+  assert.deepStrictEqual(keys, ['more', 'phase', 'platform', 'tabId', 'topFrame', 'workflow'], `buildDiagnostics keys: got ${keys}`);
+
+  assert.strictEqual(diag.phase, 'workflow');
+  assert.strictEqual(diag.workflow, 'doThing');
+  assert.strictEqual(diag.platform, 'myplatform');
+  assert.strictEqual(diag.tabId, 42);
+  assert.ok(diag.topFrame, 'topFrame should be non-null for a stack with a frame');
+  assert.ok(diag.more.includes("webpilot_dev_get_formatter_logs({platform: 'myplatform'})"), `more hint: got ${diag.more}`);
+
+  // format-phase incident: workflow should be null
+  const formatIncident = makeIncident({ phase: 'format', workflow: null, tabId: null });
+  const diagFormat = buildDiagnostics(formatIncident, 'someplatform');
+  assert.strictEqual(diagFormat.phase, 'format');
+  assert.strictEqual(diagFormat.workflow, null);
+  assert.strictEqual(diagFormat.tabId, null);
+
+  // No params/stack/timestamp in returned object
+  assert.ok(!('params' in diag), 'buildDiagnostics must not include params');
+  assert.ok(!('stack' in diag), 'buildDiagnostics must not include stack');
+  assert.ok(!('timestamp' in diag), 'buildDiagnostics must not include timestamp');
+
+  console.log('buildDiagnostics: PASS');
+}
+
+// ---------------------------------------------------------------------------
+// recordError returns the incident
+// ---------------------------------------------------------------------------
+{
+  formatterLogs._resetForTests();
+  _insertedRows.length = 0;
+
+  const incident = formatterLogs.recordError('myplatform', {
+    error: new Error('boom'),
+    phase: 'format',
+    tabId: 7
+  });
+
+  assert.ok(incident, 'recordError should return the incident');
+  assert.strictEqual(incident.phase, 'format');
+  assert.strictEqual(incident.tabId, 7);
+  assert.strictEqual(incident.formatter, 'myplatform');
+
+  console.log('recordError returns incident: PASS');
+}
+
+// ---------------------------------------------------------------------------
+// Workflow error path: diagnostics.phase === 'workflow', correct fields
+// ---------------------------------------------------------------------------
+{
+  formatterLogs._resetForTests();
+  _insertedRows.length = 0;
+
+  const err = new Error('workflow failed');
+  err.stack = '    at runWorkflow (some-workflow.js:55:10)\n    at process.nextTick (node:internal/process/task_queues:81:21)';
+
+  // Simulate what mcp-handler's workflow catch block does (no __formatterIncident)
+  const incident = formatterLogs.recordError('discord', {
+    error: err,
+    phase: 'workflow',
+    workflow: 'sendMessage',
+    params: { text: 'hi' },
+    tabId: 99
+  });
+  const diag = formatterLogs.buildDiagnostics(incident, 'discord');
+
+  assert.strictEqual(diag.phase, 'workflow');
+  assert.strictEqual(diag.workflow, 'sendMessage');
+  assert.strictEqual(diag.platform, 'discord');
+  assert.strictEqual(diag.tabId, 99);
+  assert.ok(diag.topFrame !== null, 'topFrame should be non-null for valid stack');
+
+  console.log('workflow error path diagnostics: PASS');
+}
+
+// ---------------------------------------------------------------------------
+// Format-phase no-fallback: diagnostics.phase === 'format', workflow === null
+// ---------------------------------------------------------------------------
+{
+  formatterLogs._resetForTests();
+  _insertedRows.length = 0;
+
+  const err = new Error('formatter crashed');
+  err.stack = '    at Object.formatFn (threads-formatter.js:23:7)';
+
+  const incident = formatterLogs.recordError('threads', {
+    error: err,
+    phase: 'format',
+    tabId: 5
+  });
+  const diag = formatterLogs.buildDiagnostics(incident, 'threads');
+
+  assert.strictEqual(diag.phase, 'format');
+  assert.strictEqual(diag.workflow, null);
+  assert.strictEqual(diag.platform, 'threads');
+  assert.strictEqual(diag.tabId, 5);
+
+  console.log('format-phase diagnostics: PASS');
+}
+
+// ---------------------------------------------------------------------------
+// No-double-record: workflow path using err.__formatterIncident doesn't push
+// a duplicate entry to the ring buffer.
+// ---------------------------------------------------------------------------
+{
+  formatterLogs._resetForTests();
+  _insertedRows.length = 0;
+
+  // Simulate formatter already recording via recordError (as formatTree does)
+  const err = new Error('formatter blew up');
+  err.stack = '    at formatFn (zillow-formatter.js:10:3)';
+  const incident = formatterLogs.recordError('zillow', {
+    error: err,
+    phase: 'format',
+    tabId: 12
+  });
+  err.__formatterIncident = incident;
+  err.__platform = 'zillow';
+
+  const countBefore = formatterLogs.getLogs('zillow').length;
+  const insertsBefore = _insertedRows.length;
+
+  // Simulate mcp-handler workflow catch block: uses err.__formatterIncident, skips recordError
+  let incidentUsed;
+  if (err.__formatterIncident) {
+    incidentUsed = err.__formatterIncident;
+  } else {
+    incidentUsed = formatterLogs.recordError('zillow', { error: err, phase: 'workflow', workflow: 'foo' });
+  }
+
+  const countAfter = formatterLogs.getLogs('zillow').length;
+  const insertsAfter = _insertedRows.length;
+
+  assert.strictEqual(countAfter, countBefore, 'Ring buffer count must not grow on second path');
+  assert.strictEqual(insertsAfter, insertsBefore, 'No additional DB insert on second path');
+  assert.strictEqual(incidentUsed, incident, 'Should reuse the same incident object');
+
+  console.log('no-double-record: PASS');
+}
+
+console.log('\nAll formatter-diagnostics tests passed.');


### PR DESCRIPTION
## Summary
- Workflow & accessibility-tree errors now include an inline `diagnostics` object `{phase, workflow, platform, tabId, topFrame, more}` — agents no longer need a separate `webpilot_dev_get_formatter_logs` call to know why something failed.
- Softens the `webpilot_dev_get_formatter_logs` tool description; updates `docs/MCP_INTEGRATION.md` and `docs/MCP_SERVER.md` to match.
- Fixes a pre-existing over-broad try/catch in `formatter-manager.formatTree` that was silently swallowing no-fallback formatter errors.

Relates to #57

## Changes
| File | Change |
|------|--------|
| packages/server-for-chrome-extension/src/formatter-logs.js | Add `extractTopFrame` + `buildDiagnostics` helpers; `recordError` returns the persisted incident |
| packages/server-for-chrome-extension/src/formatter-manager.js | Stamp `__formatterIncident`/`__platform` on no-fallback rethrow; narrow URL-parse try/catch so it no longer swallows formatter errors |
| packages/server-for-chrome-extension/src/mcp-handler.js | Attach `diagnostics` to `webpilot_run_workflow` and `browser_get_accessibility_tree` error responses; rethrow on `__formatterIncident` in inner a11y-tree catch; soften `webpilot_dev_get_formatter_logs` description |
| packages/server-for-chrome-extension/test/formatter-diagnostics.test.js | New tests covering helpers, workflow error path, format-phase error path, no-double-record |
| packages/server-for-chrome-extension/package.json | Add `npm test` script |
| docs/MCP_INTEGRATION.md | Document `diagnostics` in workflow & a11y-tree error sections; soften dev-log tool table cell |
| docs/MCP_SERVER.md | Drop "DEVELOPER TOOL" prefix from dev tool rows; add brief note about `diagnostics` field |

## AI Suggested Testing Plan
- [ ] `cd packages/server-for-chrome-extension && npm test` — all 6 diagnostics tests pass
- [ ] Trigger a workflow that throws inside a formatter; confirm response contains `diagnostics.phase: 'workflow'`, correct `platform`, `tabId`, and non-null `topFrame`
- [ ] Configure a formatter with `errorHandling.fallbackToRawTree: false` and force a format-phase throw; confirm `browser_get_accessibility_tree` returns `{ok:false, error, diagnostics}` with `phase: 'format'`, `workflow: null`
- [ ] Confirm `webpilot_dev_get_formatter_logs` description no longer reads "DEVELOPER TOOL" in both the MCP tool list and `docs/MCP_INTEGRATION.md` / `docs/MCP_SERVER.md`
- [ ] Sanity: a transport/auth error (e.g. pairing failure) does NOT include a `diagnostics` field

## Ticket
#57 — https://github.com/Jtonna/WebPilot/issues/57

---
Generated by the starterpack orchestrator.