### PR TITLE
fix(ci): release.yml dry_run=true now builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
       tag: ${{ steps.plan.outputs.tag }}
       ref: ${{ steps.plan.outputs.ref }}
       should_release: ${{ steps.plan.outputs.should_release }}
+      should_build: ${{ steps.plan.outputs.should_build }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -75,11 +76,15 @@ jobs:
               return JSON.parse(fs.readFileSync('package.json', 'utf8')).version;
             }
 
-            function emit({version, tag, refOut, shouldRelease}) {
+            function emit({version, tag, refOut, shouldRelease, shouldBuild}) {
               core.setOutput('version', version || '');
               core.setOutput('tag', tag || '');
               core.setOutput('ref', refOut || '');
               core.setOutput('should_release', shouldRelease ? 'true' : 'false');
+              // Default: build whenever we'd release; dispatch with dry_run=true
+              // overrides to build-but-not-release.
+              const sb = shouldBuild === undefined ? !!shouldRelease : !!shouldBuild;
+              core.setOutput('should_build', sb ? 'true' : 'false');
             }
 
             // ---- workflow_call: dispatcher already bumped + tagged ----
@@ -111,7 +116,8 @@ jobs:
                 version,
                 tag: 'v' + version,
                 refOut: context.ref,
-                shouldRelease: !dryRun
+                shouldRelease: !dryRun,
+                shouldBuild: true
               });
             }
 
@@ -123,7 +129,7 @@ jobs:
     needs: decide
     # Mac + Linux build legs are intentionally disabled until those platforms
     # are functionally verified. Tracked in issues #48 (macOS) and #49 (Linux).
-    if: needs.decide.outputs.should_release == 'true'
+    if: needs.decide.outputs.should_build == 'true'
     runs-on: windows-latest
 
     steps:


### PR DESCRIPTION
## Summary
- release.yml workflow_dispatch with dry_run=true previously skipped the build job (the gate was tied to should_release, which is false when dry_run=true). The header docs said dry_run should build but not publish — this PR makes the behavior match the docs.
- Adds a should_build output to the decide job. build now gates on should_build; release keeps gating on should_release. Net effect for dry_run=true: build runs and publishes the .exe as an Actions artifact, no GitHub Release.

Closes #62

## Changes
| File | Change |
|------|--------|
| .github/workflows/release.yml | Add should_build output; build job now gates on should_build; release still gates on should_release |

## AI Suggested Testing Plan
- [ ] Trigger workflow_dispatch with dry_run=true on this branch — Build (windows) runs, Publish GitHub Release skips, .exe is downloadable from the run
- [ ] Trigger workflow_dispatch with dry_run=false on this branch — Build runs, Publish runs (but produces a release at the package.json version, so only do this if you actually want to release)
- [ ] Existing release-patch.yml / tag-push behavior unchanged: build + publish

---
Generated by the starterpack orchestrator.