### PR TITLE
fix(ci): single-ref checkout in release.yml to avoid Windows case collision

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,11 +133,28 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.decide.outputs.ref }}
-          fetch-depth: 0
+      - name: Checkout source (single-ref, case-collision-safe)
+        shell: bash
+        run: |
+          set -euo pipefail
+          REF='${{ needs.decide.outputs.ref }}'
+          # Strip 'refs/heads/' prefix if present so 'git fetch' treats it as a
+          # branch name. Tag refs ('refs/tags/v...') are passed through.
+          if [[ "$REF" == refs/heads/* ]]; then
+            REF="${REF#refs/heads/}"
+          fi
+          echo "Resolved ref: $REF"
+          git init -q .
+          git config --local advice.detachedHead false
+          git remote add origin "https://github.com/${{ github.repository }}.git"
+          # Fetch ONLY the target ref to avoid Windows case-insensitive FS
+          # collisions between FEAT/ and feat/ prefixed branches.
+          git fetch --no-tags --depth=0 origin "$REF"
+          git checkout --detach FETCH_HEAD
+          echo "Checked out at:"
+          git log -1 --oneline
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- The build job's `actions/checkout@v4` step issued `git fetch --prune ... +refs/heads/*:refs/remotes/origin/*` which collided lowercase + uppercase branch prefixes on the Windows runner's case-insensitive filesystem.
- Replaced that step with a manual `git init` + targeted `git fetch <ref>` + detached checkout. Only the target ref is touched, so case collisions can't occur.
- No behavior change for tag pushes or the release-{patch,minor,major} dispatchers.

Closes #64

## Changes
| File | Change |
|------|--------|
| .github/workflows/release.yml | Replace `actions/checkout@v4` in the `build` job with a single-ref bash checkout |

## AI Suggested Testing Plan
- [ ] Trigger workflow_dispatch on `feat/formatter-dev-ergonomics` with `dry_run=true` — Build (windows) succeeds, .exe is downloadable from the run, Publish GitHub Release is skipped
- [ ] Tag push behavior unchanged: pushing a `v*` tag still builds + publishes

---
Generated by the starterpack orchestrator.