### PR TITLE
fix(ci): drop --depth=0 from single-ref checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,7 @@ jobs:
           git remote add origin "https://github.com/${{ github.repository }}.git"
           # Fetch ONLY the target ref to avoid Windows case-insensitive FS
           # collisions between FEAT/ and feat/ prefixed branches.
-          git fetch --no-tags --depth=0 origin "$REF"
+          git fetch --no-tags origin "$REF"
           git checkout --detach FETCH_HEAD
           echo "Checked out at:"
           git log -1 --oneline


### PR DESCRIPTION
Follow-up to #65. `git fetch --depth=0` errors on the runner with `fatal: depth 0 is not a positive number`. Removed the flag entirely so the fetch defaults to full history.

Refs #64

Failed run: https://github.com/Jtonna/WebPilot/actions/runs/26691506775