### PR TITLE
fix(ci): escape PowerShell variable interpolation in release-notes step

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -204,7 +204,7 @@ jobs:
           $sb = New-Object System.Text.StringBuilder
           [void]$sb.AppendLine("## WebPilot ${{ steps.ver.outputs.tag }}")
           [void]$sb.AppendLine("")
-          if ($prev) { [void]$sb.AppendLine("Changes since $prev:") } else { [void]$sb.AppendLine("Initial release notes:") }
+          if ($prev) { [void]$sb.AppendLine("Changes since ${prev}:") } else { [void]$sb.AppendLine("Initial release notes:") }
           [void]$sb.AppendLine("")
           if ($feat)  { [void]$sb.AppendLine("### Features");      $feat  | ForEach-Object { [void]$sb.AppendLine($_) }; [void]$sb.AppendLine("") }
           if ($fix)   { [void]$sb.AppendLine("### Fixes");         $fix   | ForEach-Object { [void]$sb.AppendLine($_) }; [void]$sb.AppendLine("") }


### PR DESCRIPTION
## Summary
- v2.1.0 release-stable.yml failed at the release-notes step because PowerShell parses `\$prev:` as a scope/drive operator (`:` immediately after a variable name is the PowerShell scope separator).
- Fixed by wrapping the variable as `\${prev}:` so PowerShell parses it correctly.
- v2.1.0 release was salvaged via `gh release create` manually; this prevents the next release from hitting the same issue.
- release-nightly.yml does not have this bug (its `\$prev` usage is not followed by `:` in a double-quoted string).

## Test plan
- [ ] Confirm `git diff` shows only the single-character change (`\$prev:` → `\${prev}:`) in release-stable.yml
- [ ] Confirm release-nightly.yml is unchanged
- [ ] After merge, trigger a patch release dry-run to verify the notes step completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)