### PR TITLE
Fix macOS Chrome path parsing

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,28 @@ permissions:
   pull-requests: read
 
 jobs:
+  server-tests:
+    name: Server tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run server tests
+        run: npm run test --workspace=packages/server-for-chrome-extension
+
   build:
     name: Build (windows)
     # Mac + Linux build legs are intentionally disabled until those platforms

--- a/docs/CHROME_MAC.md
+++ b/docs/CHROME_MAC.md
@@ -135,17 +135,12 @@ Tick each of these by hand on first run.
       compare. The matcher is case-sensitive and whitespace-sensitive.
 - [ ] Verify `--user-data-dir=` is extracted correctly when the path
       contains spaces (e.g. `/Users/<you>/Library/Application Support/
-      Google/Chrome`). The regex in `macos-detector.extractUserDataDir`
-      handles both quoted (`"…"`) and bare-with-no-spaces forms. macOS
-      `ps -ww -o command=` output does **not** quote spaces — so the
-      bare form will capture only up to the first space and lose the
-      rest of the path. Note that `launcher.js` deliberately omits
-      `--user-data-dir` when it equals the default (see
-      `getDefaultUserDataDir()`), so the default-path case won't have
-      the flag on the cmdline at all — the regex bug only bites when an
-      explicit non-default user-data-dir containing spaces is passed.
-      Still likely to need a regex fix on first try if anyone uses a
-      custom UDD with spaces.
+      Google/Chrome`). `macos-detector.extractUserDataDir` now captures
+      unquoted macOS `ps -ww -o command=` values through the next
+      Chrome `--flag`, which covers Chrome paths containing spaces. Note
+      that `launcher.js` deliberately omits `--user-data-dir` when it
+      equals the default (see `getDefaultUserDataDir()`), so the
+      default-path case won't have the flag on the cmdline at all.
 
 ### Notification system
 

--- a/packages/server-for-chrome-extension/src/chrome/macos-detector.js
+++ b/packages/server-for-chrome-extension/src/chrome/macos-detector.js
@@ -9,17 +9,36 @@ const FLAG = '--silent-debugger-extension-api';
 // per the spec, but the author cannot fully validate it on this Windows
 // machine. Cross-platform smoke testing required before relying on this.
 
-function extractUserDataDir(cmdLine) {
+function extractFlagValue(cmdLine, flag) {
   if (!cmdLine) return null;
-  let m = cmdLine.match(/--user-data-dir=(?:"([^"]*)"|(\S+))/);
-  if (m) return m[1] || m[2] || null;
+
+  const marker = `${flag}=`;
+  const start = cmdLine.indexOf(marker);
+  if (start === -1) return null;
+
+  const raw = cmdLine.slice(start + marker.length).trimStart();
+  if (!raw) return null;
+
+  if (raw.startsWith('"')) {
+    const endQuote = raw.indexOf('"', 1);
+    if (endQuote !== -1) return raw.slice(1, endQuote);
+    return raw.slice(1).trim() || null;
+  }
+
+  const nextFlag = raw.search(/\s--[A-Za-z0-9][A-Za-z0-9-]*(?:=|\s|$)/);
+  const value = nextFlag === -1 ? raw : raw.slice(0, nextFlag);
+  return value.trim() || null;
+}
+
+function extractUserDataDir(cmdLine) {
+  const value = extractFlagValue(cmdLine, '--user-data-dir');
+  if (value) return value;
   return null;
 }
 
 function extractProfileDirectory(cmdLine) {
-  if (!cmdLine) return null;
-  const m = cmdLine.match(/--profile-directory=(?:"([^"]*)"|(\S+))/);
-  if (m) return m[1] || m[2] || null;
+  const value = extractFlagValue(cmdLine, '--profile-directory');
+  if (value) return value;
   return null;
 }
 
@@ -92,4 +111,11 @@ async function detect() {
   return out;
 }
 
-module.exports = { detect, FLAG };
+module.exports = {
+  detect,
+  // Exposed for unit-test coverage of macOS ps command-line quirks.
+  _extractUserDataDir: extractUserDataDir,
+  _extractProfileDirectory: extractProfileDirectory,
+  _isBrowserParent: isBrowserParent,
+  FLAG,
+};

--- a/packages/server-for-chrome-extension/test/macos-detector.test.js
+++ b/packages/server-for-chrome-extension/test/macos-detector.test.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const assert = require('assert');
+
+const detector = require('../src/chrome/macos-detector');
+
+let passed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    console.log('  PASS', name);
+  } catch (err) {
+    console.error('  FAIL', name, '\n   ', err.message);
+    process.exitCode = 1;
+  }
+}
+
+console.log('\n[macos-detector]');
+
+test('extracts default user-data-dir containing spaces from macOS ps output', () => {
+  const cmd = [
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '--user-data-dir=/Users/alice/Library/Application Support/Google/Chrome',
+    '--profile-directory=Default',
+    detector.FLAG,
+  ].join(' ');
+
+  assert.strictEqual(
+    detector._extractUserDataDir(cmd),
+    '/Users/alice/Library/Application Support/Google/Chrome'
+  );
+});
+
+test('extracts profile-directory values containing spaces', () => {
+  const cmd = [
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '--profile-directory=Profile 2',
+    detector.FLAG,
+  ].join(' ');
+
+  assert.strictEqual(detector._extractProfileDirectory(cmd), 'Profile 2');
+});
+
+test('quoted flag values still parse', () => {
+  const cmd = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome ' +
+    '--user-data-dir="/tmp/WebPilot Chrome" --profile-directory="Profile 3"';
+
+  assert.strictEqual(detector._extractUserDataDir(cmd), '/tmp/WebPilot Chrome');
+  assert.strictEqual(detector._extractProfileDirectory(cmd), 'Profile 3');
+});
+
+test('browser parent filter excludes Chrome helper processes', () => {
+  assert.strictEqual(
+    detector._isBrowserParent('/Applications/Google Chrome.app/Contents/MacOS/Google Chrome --type=renderer'),
+    false
+  );
+  assert.strictEqual(
+    detector._isBrowserParent('/Applications/Google Chrome.app/Contents/MacOS/Google Chrome --profile-directory=Default'),
+    true
+  );
+});
+
+process.on('exit', () => {
+  if (process.exitCode) return;
+  console.log(`\nmacos-detector tests passed: ${passed}`);
+});


### PR DESCRIPTION
## Summary
- fix macOS Chrome command-line parsing so unquoted `--user-data-dir` and `--profile-directory` values can contain spaces until the next Chrome flag
- add focused macOS detector tests for the `ps -ww -o command=` cases documented in `docs/CHROME_MAC.md`
- add a lightweight PR server-test job on Windows and macOS using `npm ci --ignore-scripts`, without re-enabling the full macOS packaging leg

Part of #48. This does not claim full macOS release readiness; it addresses one concrete first-boot detector issue and gives the macOS detector a CI guard.

## Verification
- `npm run test --workspace=packages/server-for-chrome-extension`
- `node packages/server-for-chrome-extension/test/macos-detector.test.js`
- `node -e "require('./packages/server-for-chrome-extension/src/chrome/macos-detector').detect().then((rows)=>{ console.log(JSON.stringify({count: rows.length, rows: rows.map(r => ({pid:r.pid, hasFlag:r.hasFlag, userDataDir:r.userDataDir, profileDirectory:r.profileDirectory}))}, null, 2)); })"` on macOS with Chrome running
- `git diff --check`

## Notes
- I intentionally kept the existing Windows packaging job untouched. The new macOS CI coverage is server tests only, because #48 still calls for manual Intel + Apple Silicon smoke tests before shipping a `.dmg`.
- A full local `npm ci` with install scripts was not a useful signal here on my machine: it stalled while installing the full Electron/native dependency tree. The added CI test job uses `npm ci --ignore-scripts`, which is sufficient for these pure JS server tests.
