### PR TITLE
feat(server,ui): dynamic version display from release-info.json (#69)

### DIFF
--- a/packages/server-for-chrome-extension/package.json
+++ b/packages/server-for-chrome-extension/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "bin": "cli.js",
   "scripts": {
-    "test": "node test/formatter-diagnostics.test.js && node test/platform-guide-gate.test.js && node test/formatter-updater-ref.test.js",
+    "test": "node test/formatter-diagnostics.test.js && node test/platform-guide-gate.test.js && node test/formatter-updater-ref.test.js && node test/release-info.test.js",
     "start": "node index.js",
     "dev": "cross-env WEBPILOT_DEV=1 node --watch index.js",
     "dev:network": "cross-env WEBPILOT_DEV=1 node --watch index.js --network",

--- a/packages/server-for-chrome-extension/src/mcp-handler.js
+++ b/packages/server-for-chrome-extension/src/mcp-handler.js
@@ -6,6 +6,7 @@ const { findInTree } = require('./lib/tree-query');
 const formatterLogs = require('./formatter-logs');
 const sitePolicy = require('./site-policy');
 const formatterUnlockState = require('./formatter-unlock-state');
+const { getReleaseInfo } = require('./release-info');
 
 // Tools that operate on an existing tab_id and therefore need a per-call
 // current-URL policy check (checkpoint B in the site-policy gate).
@@ -836,7 +837,7 @@ function createMcpHandler(extensionBridge, pairedKeys, formatterManager, isPairi
         result: {
           protocolVersion: '2024-11-05',
           capabilities: { tools: {} },
-          serverInfo: { name: 'WebPilot', version: '2.1.1' },
+          serverInfo: { name: 'WebPilot', version: getReleaseInfo().version },
           instructions: `WebPilot is an MCP server that controls a real Chrome browser via a paired Chrome extension. All browser interactions happen in the user's actual browser, not a headless instance.
 
 **Authentication — read this first.** Every browser_* tool requires a paired API key. If you do NOT already have one for this server (i.e., your client config has no X-API-Key header / api_key parameter): your FIRST action must be to call \`request_pairing\` with a memorable agent_name. That tool returns immediately with a pairing_id and status — read its description and follow the async flow (surface the approval URL to the human, stop calling browser_* tools, poll \`check_pairing_status\` later). Skipping this step means every browser tool call will fail with an authentication error. The tools \`request_pairing\`, \`check_pairing_status\`, \`webpilot_get_formatter_info\`, and \`webpilot_dev_get_formatter_logs\` do NOT require a key.

--- a/packages/server-for-chrome-extension/src/release-info.js
+++ b/packages/server-for-chrome-extension/src/release-info.js
@@ -1,0 +1,72 @@
+'use strict';
+
+/**
+ * getReleaseInfo() — single source of truth for build provenance.
+ *
+ * At build time the CI workflow writes
+ *   packages/server-for-chrome-extension/release-info.json
+ * containing { ref, channel, version, builtAt }.
+ *
+ * At runtime (both plain Node and inside a pkg binary snapshot) this module
+ * reads that file once and memoises the result. All consumers — serverInfo,
+ * /api/ui/release, the UI version display — call getReleaseInfo() so version
+ * is always derived from a single location.
+ *
+ * Fallback (dev checkouts / legacy builds / any parse error):
+ *   { ref: null, channel: 'dev', version: <package.json version>, builtAt: null }
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+let _cached = null;
+
+function getReleaseInfo() {
+  if (_cached !== null) return _cached;
+
+  const infoPath = path.join(__dirname, '..', 'release-info.json');
+  try {
+    const raw = fs.readFileSync(infoPath, 'utf8');
+    const info = JSON.parse(raw);
+
+    // Validate shape: all four fields must be present, non-empty strings.
+    const required = ['ref', 'channel', 'version', 'builtAt'];
+    const allPresent = required.every(
+      (k) => info && typeof info[k] === 'string' && info[k].length > 0
+    );
+
+    if (allPresent) {
+      _cached = {
+        ref: info.ref,
+        channel: info.channel,
+        version: info.version,
+        builtAt: info.builtAt,
+      };
+      return _cached;
+    }
+
+    console.warn('[release-info] release-info.json is missing required fields — falling back to dev');
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      // Malformed JSON or unexpected read error — worth logging.
+      console.warn('[release-info] release-info.json missing or malformed — falling back to dev');
+    }
+    // ENOENT in dev checkouts: silent fallback.
+  }
+
+  // Fallback: derive version from package.json (always present, pkg snapshots bundle it).
+  let pkgVersion = '0.0.0';
+  try {
+    pkgVersion = require('../package.json').version;
+  } catch (_e) { /* ignore */ }
+
+  _cached = { ref: null, channel: 'dev', version: pkgVersion, builtAt: null };
+  return _cached;
+}
+
+// Allow tests to reset the memo between scenarios.
+function _resetCache() {
+  _cached = null;
+}
+
+module.exports = { getReleaseInfo, _resetCache };

--- a/packages/server-for-chrome-extension/src/server.js
+++ b/packages/server-for-chrome-extension/src/server.js
@@ -16,6 +16,7 @@ const notificationsSettings = require('./notifications-settings');
 const { createChromeManager, readProfiles } = require('./chrome');
 
 const { getDataDir, getLogPath } = require('./service/paths');
+const { getReleaseInfo } = require('./release-info');
 
 /**
  * Resolve the absolute path to the WebPilot Chrome-extension folder the user
@@ -440,6 +441,18 @@ function mountWebUiRoutes(app, deps) {
   // Extra localhost gate layered onto every mutating admin endpoint. See
   // makeMutatingUiAuth() for the rationale.
   const mutatingAuth = makeMutatingUiAuth(hostBinding);
+
+  // Build provenance — channel, version, ref, builtAt. Read-only; no auth
+  // beyond the standard localhost gate. Returns the memoised release-info
+  // object (or dev fallback if release-info.json is absent).
+  app.get('/api/ui/release', auth, (req, res) => {
+    try {
+      res.json(getReleaseInfo());
+    } catch (e) {
+      console.error('[ui-api] /api/ui/release failed:', e.message);
+      res.status(500).json({ error: 'Failed to read release info' });
+    }
+  });
 
   app.get('/api/ui/status', auth, async (req, res) => {
     try {

--- a/packages/server-for-chrome-extension/test/release-info.test.js
+++ b/packages/server-for-chrome-extension/test/release-info.test.js
@@ -1,0 +1,187 @@
+'use strict';
+
+/**
+ * Tests for release-info.js (issue #69).
+ *
+ * Verifies that getReleaseInfo() returns the parsed release-info.json when it
+ * is present and well-formed, and falls back to package.json version with
+ * channel='dev' when it is missing or malformed.
+ *
+ * Strategy: stub `fs.readFileSync` and `require('../package.json')` via
+ * Module._load, then reload release-info.js fresh for each scenario using
+ * the _resetCache() export.
+ */
+
+const assert = require('assert');
+const Module = require('module');
+
+const origLoad = Module._load.bind(Module);
+
+// Per-scenario content for release-info.json (null = ENOENT)
+let _releaseInfoContent = null;
+// Per-scenario package.json version
+let _pkgVersion = '9.8.7';
+
+Module._load = function (request, parent, isMain) {
+  const key = request.replace(/\\/g, '/');
+
+  if (request === 'fs' || key === 'fs') {
+    const realFs = origLoad(request, parent, isMain);
+    return new Proxy(realFs, {
+      get(target, prop) {
+        if (prop === 'readFileSync') {
+          return function (filePath, encoding) {
+            const p = String(filePath).replace(/\\/g, '/');
+            if (p.endsWith('release-info.json')) {
+              if (_releaseInfoContent === null) {
+                const err = new Error('ENOENT: no such file or directory: ' + filePath);
+                err.code = 'ENOENT';
+                throw err;
+              }
+              return _releaseInfoContent;
+            }
+            return target.readFileSync(filePath, encoding);
+          };
+        }
+        const v = target[prop];
+        return typeof v === 'function' ? v.bind(target) : v;
+      },
+    });
+  }
+
+  // Intercept require('../package.json') from within release-info.js
+  if (key.endsWith('/package.json') && !key.includes('node_modules')) {
+    return { version: _pkgVersion };
+  }
+
+  return origLoad(request, parent, isMain);
+};
+
+// ---- helpers ----
+let testCount = 0;
+let passCount = 0;
+
+function test(name, fn) {
+  testCount++;
+  try {
+    fn();
+    passCount++;
+    console.log('  PASS', name);
+  } catch (err) {
+    console.error('  FAIL', name, '\n   ', err.message);
+    process.exitCode = 1;
+  }
+}
+
+function reloadReleaseInfo() {
+  const key = require.resolve('../src/release-info');
+  delete require.cache[key];
+  return require('../src/release-info');
+}
+
+// ---- scenarios ----
+console.log('\n[release-info] getReleaseInfo() coverage');
+
+// Scenario 1: well-formed release-info.json → parsed content returned
+test('well-formed release-info.json → returns parsed { ref, channel, version, builtAt }', () => {
+  _releaseInfoContent = JSON.stringify({
+    ref: 'v2.1.0',
+    channel: 'stable',
+    version: '2.1.0',
+    builtAt: '2026-05-31T00:00:00Z',
+  });
+  const { getReleaseInfo } = reloadReleaseInfo();
+  const info = getReleaseInfo();
+  assert.strictEqual(info.ref, 'v2.1.0');
+  assert.strictEqual(info.channel, 'stable');
+  assert.strictEqual(info.version, '2.1.0');
+  assert.strictEqual(info.builtAt, '2026-05-31T00:00:00Z');
+});
+
+// Scenario 2: memoisation — second call returns the same object reference
+test('memoisation — repeated calls return same object (no re-read)', () => {
+  _releaseInfoContent = JSON.stringify({
+    ref: 'v2.1.0',
+    channel: 'stable',
+    version: '2.1.0',
+    builtAt: '2026-05-31T00:00:00Z',
+  });
+  const { getReleaseInfo, _resetCache } = reloadReleaseInfo();
+  const a = getReleaseInfo();
+  const b = getReleaseInfo();
+  assert.strictEqual(a, b, 'Both calls should return the same cached object reference');
+});
+
+// Scenario 3: file missing (ENOENT) → fallback with channel='dev'
+test('release-info.json missing (ENOENT) → channel=dev, version from package.json', () => {
+  _releaseInfoContent = null; // triggers ENOENT
+  _pkgVersion = '9.8.7';
+  const { getReleaseInfo } = reloadReleaseInfo();
+  const info = getReleaseInfo();
+  assert.strictEqual(info.channel, 'dev');
+  assert.strictEqual(info.version, '9.8.7');
+  assert.strictEqual(info.ref, null);
+  assert.strictEqual(info.builtAt, null);
+});
+
+// Scenario 4: malformed JSON → fallback + console.warn
+test('release-info.json malformed JSON → channel=dev, version from package.json, logs warn', () => {
+  _releaseInfoContent = '{ not valid json !!!';
+  _pkgVersion = '9.8.7';
+  let warnCalled = false;
+  let warnText = '';
+  const origWarn = console.warn;
+  console.warn = (...args) => { warnCalled = true; warnText += args.join(' '); };
+  let info;
+  try {
+    const { getReleaseInfo } = reloadReleaseInfo();
+    info = getReleaseInfo();
+  } finally {
+    console.warn = origWarn;
+  }
+  assert.strictEqual(info.channel, 'dev');
+  assert.strictEqual(info.version, '9.8.7');
+  assert.strictEqual(warnCalled, true, 'Malformed JSON should emit console.warn');
+  assert.ok(
+    warnText.includes('malformed') || warnText.includes('falling back'),
+    `Warning text should mention malformed/fallback, got: ${warnText}`
+  );
+});
+
+// Scenario 5: partially-formed release-info.json (missing field) → fallback
+test('release-info.json missing required field → channel=dev fallback', () => {
+  // builtAt is missing
+  _releaseInfoContent = JSON.stringify({ ref: 'v2.1.0', channel: 'stable', version: '2.1.0' });
+  _pkgVersion = '9.8.7';
+  let warnCalled = false;
+  const origWarn = console.warn;
+  console.warn = () => { warnCalled = true; };
+  let info;
+  try {
+    const { getReleaseInfo } = reloadReleaseInfo();
+    info = getReleaseInfo();
+  } finally {
+    console.warn = origWarn;
+  }
+  assert.strictEqual(info.channel, 'dev', 'Partial release-info should fall back to dev channel');
+  assert.strictEqual(info.version, '9.8.7');
+  assert.strictEqual(warnCalled, true, 'Missing field should emit console.warn');
+});
+
+// Scenario 6: nightly release-info.json → returned as-is
+test('nightly release-info.json → channel=nightly, version includes nightly tag', () => {
+  _releaseInfoContent = JSON.stringify({
+    ref: 'v2.1.1-nightly.20260531',
+    channel: 'nightly',
+    version: '2.1.1-nightly.20260531',
+    builtAt: '2026-05-31T12:00:00Z',
+  });
+  const { getReleaseInfo } = reloadReleaseInfo();
+  const info = getReleaseInfo();
+  assert.strictEqual(info.channel, 'nightly');
+  assert.ok(info.version.includes('nightly'), `Expected nightly in version, got: ${info.version}`);
+  assert.strictEqual(info.ref, 'v2.1.1-nightly.20260531');
+});
+
+console.log(`\n${passCount}/${testCount} release-info tests passed`);
+if (passCount < testCount) process.exitCode = 1;

--- a/packages/server-web-ui/app/settings/page.js
+++ b/packages/server-web-ui/app/settings/page.js
@@ -8,6 +8,7 @@ import Toggle from '../../components/Toggle';
 import { useToast } from '../../components/ToastRegion';
 import {
   getStatus,
+  getReleaseInfo,
   setNetworkMode as apiSetNetworkMode,
   setNotificationSettings,
   restartServer,
@@ -40,6 +41,8 @@ export default function SettingsPage() {
   const [theme, setThemeState] = useState('system');
   const [notifOn, setNotifOn] = useState(true);
   const [soundOn, setSoundOn] = useState(true);
+  // null = still loading; populated once /api/ui/release responds.
+  const [releaseInfo, setReleaseInfo] = useState(null);
   const toast = useToast();
   // The settings copy buttons toast success/failure with a per-call label.
   // We close over `pendingLabelRef` so the hook's onSuccess/onError handlers
@@ -77,6 +80,9 @@ export default function SettingsPage() {
     refresh();
     const storedTheme = getTheme();
     setThemeState(storedTheme || 'system');
+    // Load build provenance independently so a slow status call
+    // does not delay the version display.
+    getReleaseInfo().then(setReleaseInfo).catch(() => { /* non-fatal */ });
   }, []);
 
   function handleThemeChange(value) {
@@ -181,7 +187,13 @@ export default function SettingsPage() {
 
           <div className="wp-inset-row">
             <div className="wp-inset-row-grow">
-              <div className="wp-inset-row-title">WebPilot v1.0.0</div>
+              <div className="wp-inset-row-title">
+                {releaseInfo === null
+                  ? 'WebPilot …'
+                  : releaseInfo.channel === 'stable'
+                    ? `WebPilot v${releaseInfo.version}`
+                    : `WebPilot v${releaseInfo.version} (${releaseInfo.channel})`}
+              </div>
               <div className="wp-inset-row-sub">A local-first browser bridge for MCP agents.</div>
             </div>
           </div>

--- a/packages/server-web-ui/lib/api.js
+++ b/packages/server-web-ui/lib/api.js
@@ -52,6 +52,12 @@ export function getStatus() {
   return apiFetch('/api/ui/status');
 }
 
+// Build provenance — { ref, channel, version, builtAt }.
+// Returns dev fallback when release-info.json is absent (local dev checkout).
+export function getReleaseInfo() {
+  return apiFetch('/api/ui/release');
+}
+
 export function approvePairing(pairingId, profileId, newProfileName) {
   const body = { profileId: profileId || null };
   if (profileId === '__new__' && newProfileName) {

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -138,13 +138,8 @@ updateJson(
 );
 
 // 6. packages/server-for-chrome-extension/src/mcp-handler.js
-//    Replace version: '...' inside the serverInfo object (single-line form).
-//    Pattern is anchored to the serverInfo object to avoid matching other version fields.
-updateJs(
-  path.join(ROOT, 'packages/server-for-chrome-extension/src/mcp-handler.js'),
-  /serverInfo:\s*\{[^}]*version:\s*'[^']*'/,
-  (matched) => matched.replace(/version:\s*'[^']*'/, "version: '" + newVersion + "'")
-);
+//    (no-op since #69) — serverInfo.version is now read dynamically from
+//    release-info.json via getReleaseInfo(). No literal to patch here.
 
 // 7. packages/server-for-chrome-extension/package-lock.json
 //    Update both top-level "version" and packages[""].version


### PR DESCRIPTION
## Summary

- **Single source of truth**: both the MCP `serverInfo` response and the Settings/About UI now derive their version from `release-info.json` (written by the release workflow), eliminating the hardcoded `v1.0.0` / `v2.1.1` literals.
- **New `/api/ui/release` endpoint**: returns `{ ref, channel, version, builtAt }` to the web UI; dev fallback (`channel: 'dev'`, version from `package.json`) is used when `release-info.json` is absent.
- **`bump-version.js` cleaned up**: the `updateJs` step that regex-patched the `serverInfo` literal in `mcp-handler.js` is removed (replaced with a no-op comment) since the literal no longer exists.

## Architecture

`release-info.json` (written by CI at build time) is the single source of truth. A new `release-info.js` module reads and memoises it on first call. All consumers call `getReleaseInfo()` — no file is read more than once per process lifetime.

## File changes

| File | Change |
|------|--------|
| `packages/server-for-chrome-extension/src/release-info.js` | New — memoised reader + dev fallback |
| `packages/server-for-chrome-extension/src/mcp-handler.js` | `serverInfo.version` → `getReleaseInfo().version` |
| `packages/server-for-chrome-extension/src/server.js` | New `GET /api/ui/release` endpoint |
| `packages/server-web-ui/lib/api.js` | New `getReleaseInfo()` fetch wrapper |
| `packages/server-web-ui/app/settings/page.js` | Replaces hardcoded `v1.0.0` with dynamic render |
| `scripts/bump-version.js` | Removes `mcp-handler.js` literal-patch step |
| `packages/server-for-chrome-extension/test/release-info.test.js` | New — 6 test cases |
| `packages/server-for-chrome-extension/package.json` | Wires new test into `npm test` chain |

## Testing plan

- [ ] `npm test` in `packages/server-for-chrome-extension` — all tests pass including 6 new `release-info` tests (32 total)
- [ ] After a stable release, dashboard Settings/About shows `WebPilot v<X.Y.Z>` matching the release tag
- [ ] After a nightly release, dashboard shows `WebPilot v<X.Y.Z-nightly.YYYYMMDD> (nightly)` matching the tag
- [ ] Dev mode (no `release-info.json` present) shows `WebPilot v<package.json version> (dev)` with no errors in daemon log
- [ ] While the `/api/ui/release` fetch is in flight, the About row shows `WebPilot …` (no flash of stale hardcoded text)
- [ ] `node scripts/bump-version.js <version>` completes without errors (no longer tries to patch the removed literal)

Closes #69