### PR TITLE
fix(extension): remove orphaned client-side whitelist gate (#80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+- fix(extension): remove orphaned client-side whitelist gate — site-policy enforcement is now server-side only (`mcp-handler.js` + `site-policy.js:isAllowed`). Fixes regression introduced 2026-05-17 (commit `4009982`) where new installs and cleared chrome.storage triggered block-all with no in-extension UI to recover. (#80)
+
 ## [1.1.8]
 
 ### Added

--- a/docs/ADDING_NEW_FEATURES.md
+++ b/docs/ADDING_NEW_FEATURES.md
@@ -71,7 +71,7 @@ case 'browser_your_tool_name': {
 }
 ```
 
-Define the `_browserYourToolName(args, apiKey)` helper higher up in `mcp-handler.js` alongside the other `_browser*` helpers — it owns the policy / whitelist checks and the WebSocket round-trip to the extension via `extension-bridge.js`.
+Define the `_browserYourToolName(args, apiKey)` helper higher up in `mcp-handler.js` alongside the other `_browser*` helpers — it owns the site-policy checks and the WebSocket round-trip to the extension via `extension-bridge.js`.
 
 If you opt into the legacy fall-through pattern instead, declare `commandType` and `commandParams`, then break — the trailing dispatch handles wrapping:
 

--- a/docs/CHROME_EXTENSION.md
+++ b/docs/CHROME_EXTENSION.md
@@ -206,7 +206,7 @@ Persistent CDP debugger session management.
 
 ## Popup UI
 
-The popup was gutted to a **minimal status-and-escape-hatch panel** themed to match the webapp. All admin (agent management, sites management, pairing approval, profile picker, network-mode toggle, site policy) moved to the server-hosted web UI at `http://localhost:3456/ui/`. The popup files are still `popup/popup.html` + `popup/popup.js` + `popup/popup.css`.
+The popup is a **minimal status-and-escape-hatch panel** themed to match the webapp. Agent management, sites management, pairing approval, profile picker, network-mode toggle, and site policy live in the web UI at `http://localhost:3456/ui/`. Popup files: `popup/popup.html`, `popup/popup.js`, `popup/popup.css`.
 
 ### What the popup shows
 
@@ -264,11 +264,8 @@ Writes a `source='user'` row to `global_site_rules` via `sitePolicy.setGlobalRul
 
 It does **not** send any `chrome.runtime.sendMessage` to the background service worker, and the worker does not broadcast popup-targeted messages. The popup is decoupled from the worker's runtime state — it polls the server directly.
 
-### Per-profile reload required
-
-The popup change requires a **one-time chrome://extensions/ reload per profile** to install the new HTML/JS/CSS. The extension version was bumped to **`1.1.4`** when the popup was rewritten, and the 2026-05-17 auth cutover (transport-key retirement + `apiKey`-storage purge) shipped in subsequent `1.1.x` releases — the current manifest version is **`2.2.0`** (see `packages/chrome-extension-unpacked/manifest.json`). You can confirm which copy is live from `chrome://extensions/`.
-
-For developers: the `webpilot_dev_reload_extension` MCP tool automates the reload on the *calling agent's* paired profile (the server routes `reload_extension` to that one profile's WebSocket). Multi-profile installs still need one tool call per profile (or a manual reload in each profile's `chrome://extensions/` page) — see `accessibility-tree-formatters/DEV_GUIDE.md` for the per-profile-scope details.
+### Per-profile installation
+Each Chrome profile loads its own copy of the extension. The `webpilot_dev_reload_extension` MCP tool reloads the extension on the calling agent's paired profile; the server routes `reload_extension` to that one profile's WebSocket. Multi-profile installs need one tool call per profile, or a manual reload at `chrome://extensions/` in each profile (see `accessibility-tree-formatters/DEV_GUIDE.md`).
 
 ### Web UI takeover
 

--- a/docs/CHROME_EXTENSION.md
+++ b/docs/CHROME_EXTENSION.md
@@ -206,7 +206,7 @@ Persistent CDP debugger session management.
 
 ## Popup UI
 
-The popup was gutted to a **minimal status-and-escape-hatch panel** themed to match the webapp. All admin (agent management, sites management, pairing approval, profile picker, network-mode toggle, restricted-mode whitelist) moved to the server-hosted web UI at `http://localhost:3456/ui/`. The popup files are still `popup/popup.html` + `popup/popup.js` + `popup/popup.css`.
+The popup was gutted to a **minimal status-and-escape-hatch panel** themed to match the webapp. All admin (agent management, sites management, pairing approval, profile picker, network-mode toggle, site policy) moved to the server-hosted web UI at `http://localhost:3456/ui/`. The popup files are still `popup/popup.html` + `popup/popup.js` + `popup/popup.css`.
 
 ### What the popup shows
 
@@ -266,7 +266,7 @@ It does **not** send any `chrome.runtime.sendMessage` to the background service 
 
 ### Per-profile reload required
 
-The popup change requires a **one-time chrome://extensions/ reload per profile** to install the new HTML/JS/CSS. The extension version was bumped to **`1.1.4`** when the popup was rewritten, and the 2026-05-17 auth cutover (transport-key retirement + `apiKey`-storage purge) shipped in subsequent `1.1.x` releases — the current manifest version is **`1.1.8`** (see `packages/chrome-extension-unpacked/manifest.json`). You can confirm which copy is live from `chrome://extensions/`.
+The popup change requires a **one-time chrome://extensions/ reload per profile** to install the new HTML/JS/CSS. The extension version was bumped to **`1.1.4`** when the popup was rewritten, and the 2026-05-17 auth cutover (transport-key retirement + `apiKey`-storage purge) shipped in subsequent `1.1.x` releases — the current manifest version is **`2.2.0`** (see `packages/chrome-extension-unpacked/manifest.json`). You can confirm which copy is live from `chrome://extensions/`.
 
 For developers: the `webpilot_dev_reload_extension` MCP tool automates the reload on the *calling agent's* paired profile (the server routes `reload_extension` to that one profile's WebSocket). Multi-profile installs still need one tool call per profile (or a manual reload in each profile's `chrome://extensions/` page) — see `accessibility-tree-formatters/DEV_GUIDE.md` for the per-profile-scope details.
 
@@ -290,8 +290,6 @@ Settings and state are stored in `chrome.storage.local`:
 |-----|------|---------|-------------|
 | `focusNewTabs` | boolean | false | Whether new tabs receive focus |
 | `tabMode` | string | `'group'` | Tab organization mode (`'group'` or `'window'`) |
-| `restrictedModeEnabled` | boolean | true | Whether restricted mode is active |
-| `whitelistedDomains` | string[] | `[]` | Whitelisted domains for restricted mode |
 | `serverUrl` | string | null | WebSocket server URL (from `/connect`) |
 | `sseUrl` | string | null | SSE endpoint URL |
 | `networkMode` | boolean | false | Cached network mode flag (UI hint only) |
@@ -384,4 +382,4 @@ From `packages/chrome-extension-unpacked/manifest.json`:
 
 Host permission `<all_urls>` allows the extension to operate on any website.
 
-Manifest fields: `manifest_version: 3`, `name: "WebPilot"`, `version: "1.1.8"`. The background service worker is declared with `"type": "module"`.
+Manifest fields: `manifest_version: 3`, `name: "WebPilot"`, `version: "2.2.0"`. The background service worker is declared with `"type": "module"`.

--- a/docs/MCP_INTEGRATION.md
+++ b/docs/MCP_INTEGRATION.md
@@ -50,32 +50,20 @@ The web UI's Agents page exposes a profile dropdown per row. Selecting a differe
 
 Unauthenticated or invalid-key requests receive MCP error code `-32001`.
 
-## Security: Restricted Mode
+## Security: Site Policy
 
-**Restricted mode is ON by default.** All MCP commands that interact with web pages are blocked until the domain is explicitly whitelisted by the user. This prevents automated actions on sensitive sites without user consent.
+Site-policy enforcement is **server-side**, implemented by `isAllowed(agentId, url)` in `packages/server-for-chrome-extension/src/site-policy.js`. The extension does not enforce site policy — it executes commands. See `docs/MCP_SERVER.md` for the canonical reference.
 
-**Affected commands:**
-- `browser_create_tab`
-- `browser_close_tab`
-- `browser_get_accessibility_tree`
-- `browser_inject_script`
-- `browser_execute_js`
-- `browser_click`
-- `browser_scroll`
-- `browser_type`
+**Enforcement point:** every `browser_*` tool call (`browser_create_tab`, `browser_close_tab`, `browser_get_accessibility_tree`, `browser_inject_script`, `browser_execute_js`, `browser_click`, `browser_scroll`, `browser_type`) and `webpilot_run_workflow` is checked by `mcp-handler.js` at MCP dispatch time (checkpoints A and B) before the command reaches the extension. `browser_get_tabs` is exempt (no URL context).
 
-**Unaffected commands:**
-- `browser_get_tabs` (read-only, no interaction)
-- `browser_request_chain` (orchestrator only -- individual steps are still subject to domain restrictions)
+**Precedence (highest first):**
 
-**Blocked command error:**
-When a command is blocked, the MCP server returns:
-```
-Blocked: [domain] is not whitelisted. The human must manually add this site to the whitelist in the WebPilot extension before automation can proceed.
-```
+1. **Per-agent overrides** — rows in the `agent_site_overrides` table, scoped to the calling agent.
+2. **Global user rules** — rows in `global_site_rules` with `source='user'`, applied to all agents on this host.
+3. **Baseline blocklist** — rows in `global_site_rules` with `source='baseline'`, populated by `blocklist-updater.js` from the bundled `baseline-blocklists/` and gated by `config.baseline_blocklist_enabled`.
+4. **Default: allow.**
 
-**Managing the whitelist:**
-Users can add domains to the whitelist via the WebPilot extension popup UI. Domain matching is domain-level (e.g., whitelisting `example.com` allows both `example.com` and `subdomain.example.com`).
+**Managing site policy:** the web UI at `http://localhost:3456/ui/sites/` is the canonical surface for adding per-agent overrides, global user rules, and toggling the baseline blocklist.
 
 **Note on `api_key` parameter:** All tools except the four auth-exempt tools (`request_pairing`, `check_pairing_status`, `webpilot_get_formatter_info`, `webpilot_reload_formatters`) include an optional `api_key` string parameter in their schema. This is an alternative way to authenticate per-request without configuring the `X-API-Key` header. The `api_key` parameter is omitted from the individual tool documentation below for brevity.
 

--- a/packages/chrome-extension-unpacked/background.js
+++ b/packages/chrome-extension-unpacked/background.js
@@ -40,32 +40,12 @@ let config = {
   serverUrl: null
 };
 
-// Restricted mode whitelist cache
-let restrictedModeCache = {
-  enabled: true,  // default ON
-  domains: [],    // default empty = block all
-  loaded: false   // true once storage has been read
-};
-
-// Initialize cache from storage
-let _whitelistReady = new Promise((resolve) => {
-  chrome.storage.local.get(['restrictedModeEnabled', 'whitelistedDomains'], (result) => {
-    restrictedModeCache.enabled = result.restrictedModeEnabled !== false; // default true
-    restrictedModeCache.domains = result.whitelistedDomains || [];
-    restrictedModeCache.loaded = true;
-    resolve();
-  });
-});
+// Vestigial keys from a removed client-side whitelist gate (issue #80); site policy is enforced server-side.
+chrome.storage.local.remove(['restrictedModeEnabled', 'whitelistedDomains']);
 
 // Extension lifecycle
 chrome.runtime.onInstalled.addListener(() => {
   console.log('WebPilot extension installed');
-  // Explicitly initialize restricted mode to ON if not already set by user
-  chrome.storage.local.get(['restrictedModeEnabled'], (result) => {
-    if (result.restrictedModeEnabled === undefined) {
-      chrome.storage.local.set({ restrictedModeEnabled: true });
-    }
-  });
   // Mint a persistent installId on first install so the server can map this
   // extension install to a Chrome profileId independently of
   // extension-storage state. Idempotent — only set if not already present.
@@ -638,8 +618,6 @@ async function handleServerCommand(message) {
   }
 
   try {
-    await checkWhitelist(type, params);
-
     let result;
 
     switch (type) {
@@ -716,51 +694,6 @@ function sendResult(id, success, result, error = null) {
   }
 }
 
-// Whitelist helper functions
-function isDomainWhitelisted(url) {
-  if (!restrictedModeCache.enabled) return true;
-
-  try {
-    const hostname = new URL(url).hostname.toLowerCase();
-    return restrictedModeCache.domains.some(entry =>
-      hostname === entry || hostname.endsWith('.' + entry)
-    );
-  } catch {
-    return false; // fail-closed: invalid URLs are blocked
-  }
-}
-
-async function checkWhitelist(type, params) {
-  // Wait for cache to be populated from storage on service worker startup
-  if (!restrictedModeCache.loaded) {
-    await _whitelistReady;
-  }
-
-  if (!restrictedModeCache.enabled) return; // restricted mode off, allow all
-  if (type === 'get_tabs') return; // get_tabs is always allowed
-
-  let url;
-  if (type === 'create_tab') {
-    url = params.url;
-  } else if (params.tab_id) {
-    try {
-      const tab = await chrome.tabs.get(params.tab_id);
-      url = tab.url;
-    } catch (err) {
-      // Tab doesn't exist or can't be accessed — fail-closed
-      throw new Error(`Blocked: Unable to verify tab domain (tab_id=${params.tab_id}, reason=${err.message}). The human must manually add this site to the whitelist in the WebPilot extension before automation can proceed.`);
-    }
-  } else {
-    return; // no tab context to check
-  }
-
-  if (!url || !isDomainWhitelisted(url)) {
-    let domain = 'unknown';
-    try { domain = new URL(url).hostname; } catch {}
-    throw new Error(`Blocked: ${domain} is not whitelisted. Whitelist contains: [${restrictedModeCache.domains.join(', ')}]. The human must manually add this site to the whitelist in the WebPilot extension before automation can proceed.`);
-  }
-}
-
 // Event listeners for cleanup
 chrome.webNavigation.onCompleted.addListener(handleNavigationComplete);
 
@@ -781,12 +714,6 @@ chrome.storage.onChanged.addListener((changes, namespace) => {
     }
     if (changes.serverUrl) {
       config.serverUrl = changes.serverUrl.newValue;
-    }
-    if (changes.restrictedModeEnabled) {
-      restrictedModeCache.enabled = changes.restrictedModeEnabled.newValue !== false;
-    }
-    if (changes.whitelistedDomains) {
-      restrictedModeCache.domains = changes.whitelistedDomains.newValue || [];
     }
   }
 });

--- a/packages/chrome-extension-unpacked/manifest.json
+++ b/packages/chrome-extension-unpacked/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebPilot",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Browser control via MCP for AI agents",
   "permissions": [
     "storage",


### PR DESCRIPTION
## Summary

- Deletes `checkWhitelist()` and its supporting cache from `packages/chrome-extension-unpacked/background.js`. The gate had been reading orphaned `chrome.storage.local` keys (`restrictedModeEnabled` default-true, `whitelistedDomains` default-empty) since the popup minimization in `4009982` (2026-05-17). Result: fresh installs and cleared-storage scenarios blocked every site with no in-extension UI to recover.
- Removes the `onInstalled` block that re-wrote `restrictedModeEnabled: true` on every service-worker boot — the self-perpetuating piece that made `chrome.storage.local.clear()` ineffective.
- Adds a fire-and-forget `chrome.storage.local.remove(['restrictedModeEnabled', 'whitelistedDomains'])` at module top-level so dormant data from past installs is purged.
- Manifest bumped `2.1.1 → 2.2.0`.
- Updates `docs/MCP_INTEGRATION.md` (replaces the fossilized "Restricted Mode" section with the current server-side site-policy model) and `docs/CHROME_EXTENSION.md` (drops vestigial terminology + stale version refs).

The server is the documented trust boundary per `SECURITY.md` and `f7f2bb8`. `mcp-handler.js` checkpoints A and B already call `site-policy.js:isAllowed(agentId, url)` before any command reaches the extension. The extension-side gate was a Phase-7 cleanup debt (`4009982` commit body: *"a Phase 7 cleanup pass can prune them after the popup ships"*) that didn't get pruned when Phase 7 (`a38e2f4`) ran.

## Behavior delta (deliberate)

Old extension code fail-closed when a tab's URL couldn't be resolved (`Blocked: Unable to verify tab domain`). Checkpoint B fail-opens in the same scenario (`mcp-handler.js`: *"tab not found / not navigated yet — let it through"*). This was already the server's behavior; the deletion just removes the redundant client-side fail-closed fallback.

## Test plan

QA executed live against the paired `WebPilot Dev Agent` after extension reload to v2.2.0:

- [x] `browser_create_tab(discord.com)` with no rules → tab opens, no `[policy] BLOCK` in log (default-allow path).
- [x] Add `block discord.com` global user rule via `POST /api/ui/sites` → retry returns `{policySource: "global_user"}` — server-side error shape, no "is not whitelisted / human must manually add" text anywhere.
- [x] Add per-agent `allow discord.com` override via `POST /api/ui/agents/:key/site-overrides` → retry succeeds. Precedence verified: `agent_override` > `global_user`.
- [x] `browser_create_tab(americanexpress.com)` (baseline-listed) → `{policySource: "baseline"}`.
- [x] `grep -rn "checkWhitelist\|restrictedMode\|whitelistedDomains\|_whitelistReady\|restrictedModeCache\|isDomainWhitelisted" packages/` → zero matches in source code (only the `chrome.storage.local.remove([...])` string literal in `background.js`).
- [x] Extension reconnects cleanly with fresh `installId` after storage clear; stayed connected through all 5 tool calls without dropping.

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)