### PR TITLE
fix(ci): release workflows use RELEASE_PAT to bypass main ruleset

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -24,10 +24,20 @@ Enforces the following on the `main` branch:
 
 | Actor | Type | ID | Reason |
 |-------|------|----|--------|
-| Repository admin (Jtonna) | `RepositoryRole` | `5` | Hotfix access without ceremony |
-| `github-actions[bot]` | `User` | `41898282` | `release-stable.yml` pushes version-bump commit directly to main |
+| Repository admin (Jtonna) | `RepositoryRole` | `5` | Hotfix access without ceremony; also the mechanism release workflows use (see below) |
 
-> Note: The original spec called for `actor_type: "Integration"` with the GitHub Actions app ID (15368), but GitHub's API rejects that for personal (non-org) repos — the Integration actor type requires org-level app installation. Using `actor_type: "User"` with the bot's user ID (41898282) achieves the same result.
+### How the release workflows push to main
+
+`release-stable.yml` and `release-nightly.yml` push version-bump commits and tags directly to `main`. The default `GITHUB_TOKEN` authenticates the workflow as the GitHub Actions Integration (app id `15368`), which the ruleset cannot list as a bypass actor on personal (non-org) repos — `actor_type: "Integration"` is rejected by the API for these repos.
+
+Both workflows check out using a fine-grained personal access token stored as the `RELEASE_PAT` repo secret. The PAT belongs to the admin user, whose `RepositoryRole` (id `5`) is in `bypass_actors`. Pushes from the workflow authenticate as that user, so the ruleset bypass applies.
+
+The PAT needs:
+- Repository access: this repo only (`Jtonna/WebPilot`).
+- Permissions: `Contents: Read and write`.
+- Expiry: set per your rotation cadence; 90 days is a common floor.
+
+When the PAT expires or rotates, replace the secret value at **Settings → Secrets and variables → Actions → `RELEASE_PAT`**.
 
 ---
 

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -13,11 +13,6 @@
       "actor_id": 5,
       "actor_type": "RepositoryRole",
       "bypass_mode": "always"
-    },
-    {
-      "actor_id": 41898282,
-      "actor_type": "User",
-      "bypass_mode": "always"
     }
   ],
   "rules": [

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -43,7 +43,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # PAT (admin user) is required to push the nightly tag to `main`'s
+          # commit SHA. The default GITHUB_TOKEN authenticates as the GitHub
+          # Actions Integration, which the main-branch ruleset cannot list as
+          # a bypass actor on personal (non-org) repos.
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -50,7 +50,11 @@ jobs:
         with:
           fetch-depth: 0
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # PAT (admin user) is required to push the version-bump commit + tag
+          # to `main`. The default GITHUB_TOKEN authenticates as the GitHub
+          # Actions Integration, which the main-branch ruleset cannot list as
+          # a bypass actor on personal (non-org) repos.
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

The main-branch ruleset rejects direct pushes from the default `GITHUB_TOKEN` because that token authenticates as the GitHub Actions Integration (`actor_type: Integration`, app id `15368`), which personal (non-org) repos cannot list as a bypass actor — the API rejects Integration-type entries on personal repos.

The previous workaround in `.github/rulesets/main.json` listed `actor_id: 41898282` as `actor_type: User` to represent `github-actions[bot]`. The README claimed this "achieves the same result" as the rejected Integration entry. It does not — that bot User ID is never the actor presenting itself during a default-token workflow run, so the bypass never matched.

The stable release run dispatched after merging #83 (run `27117251363`) failed at the "Commit version bump + release-info.json" step:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
remote: - 2 of 2 required status checks are expected.
```

## Fix

Switch both release workflows' checkout step to use a fine-grained PAT stored as `RELEASE_PAT`. The PAT belongs to the admin user whose `RepositoryRole` (id `5`) is in `bypass_actors`, so pushes authenticate as that user and the ruleset bypass applies.

- `release-stable.yml`: checkout token `${{ secrets.RELEASE_PAT }}` instead of `GITHUB_TOKEN`.
- `release-nightly.yml`: same.
- `.github/rulesets/main.json`: drop the dead `actor_id: 41898282` User entry.
- `.github/rulesets/README.md`: rewrite Bypass actors section to describe the actual mechanism (PAT-as-admin), drop the misleading note about User-type achieving the same result as Integration-type.

## Test plan

- [ ] Reviewer creates `RELEASE_PAT` repo secret (fine-grained PAT, this repo only, `Contents: Read+Write`).
- [ ] After merge, sync the updated ruleset to GitHub:
      `gh api -X PUT repos/Jtonna/WebPilot/rulesets/17100757 --input .github/rulesets/main.json`
- [ ] Re-dispatch `release-stable.yml` with `bump=minor` to produce `v2.2.0`.
- [ ] Re-dispatch `release-nightly.yml` after stable lands to produce `2.2.1-nightly.<YYYYMMDD>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)