### PR TITLE
#88: validate global-site-blocklists bundle in check-signed-manifest

### DIFF
--- a/.github/workflows/check-signed-manifest.yml
+++ b/.github/workflows/check-signed-manifest.yml
@@ -4,10 +4,12 @@ on:
   pull_request:
     paths:
       - 'accessibility-tree-formatters/**'
+      - 'global-site-blocklists/**'
   push:
     branches: [main]
     paths:
       - 'accessibility-tree-formatters/**'
+      - 'global-site-blocklists/**'
 
 permissions:
   contents: read
@@ -45,3 +47,29 @@ jobs:
             exit 1
           fi
           echo "All formatter file hashes match signed-manifest.json"
+
+      - name: Verify signed-manifest hashes match current blocklist files
+        shell: bash
+        run: |
+          set -euo pipefail
+          MANIFEST=global-site-blocklists/signed-manifest.json
+          if [ ! -f "$MANIFEST" ]; then
+            echo "::error::signed-manifest.json missing from global-site-blocklists/"
+            exit 1
+          fi
+          # Iterate every file claimed in signed-manifest, compute actual hash, compare.
+          fail=0
+          while IFS=$'\t' read -r file claimed; do
+            actual=$(sha256sum "global-site-blocklists/$file" | awk '{print $1}')
+            if [ "$actual" != "$claimed" ]; then
+              echo "::error file=global-site-blocklists/$file::hash mismatch — claimed $claimed, actual $actual. Run 'node scripts/sign-formatters.js' and commit the regenerated signed-manifest.json."
+              fail=1
+            fi
+          done < <(node -e '
+            const m = require("./global-site-blocklists/signed-manifest.json");
+            for (const [f, h] of Object.entries(m.files)) console.log(f + "\t" + h);
+          ')
+          if [ $fail -ne 0 ]; then
+            exit 1
+          fi
+          echo "All blocklist file hashes match signed-manifest.json"


### PR DESCRIPTION
## Summary
- Extend the "Check signed-manifest staleness" CI workflow to also guard the `global-site-blocklists/` bundle, so a stale `global-site-blocklists/signed-manifest.json` fails CI exactly like the `accessibility-tree-formatters` bundle already does.
- Adds `global-site-blocklists/**` to the workflow's `pull_request` and `push` path triggers, and appends a second `verify`-job step that hashes every file claimed in the blocklist manifest against on-disk content (raw `sha256sum`, no LF normalization).
- Closes #88

## Changes
| File | Change |
|------|--------|
| `.github/workflows/check-signed-manifest.yml` | Added `global-site-blocklists/**` to both `pull_request.paths` and `push.paths`; appended a second verify step ("Verify signed-manifest hashes match current blocklist files") cloned from the existing formatters check. |

## AI Suggested Testing Plan
- [ ] CI on this PR runs the new "Verify signed-manifest hashes match current blocklist files" step and it passes (the manifest currently matches on-disk content).
- [ ] Tamper with `global-site-blocklists/financial-institutions.txt` without re-signing on a scratch branch → confirm the new step fails with the blocklist-named error message.
- [ ] Confirm a change under `global-site-blocklists/**` now triggers the workflow via the new path filter.

## Ticket
#88 — https://github.com/Jtonna/WebPilot/issues/88

---
Generated by the starterpack orchestrator.
